### PR TITLE
Case insensitive sorting

### DIFF
--- a/alphabetize_codeowners.py
+++ b/alphabetize_codeowners.py
@@ -70,7 +70,7 @@ def sort_line(line: str) -> str:
     dedented = line.lstrip()
     elements = WS_PAT.split(dedented)
     path = elements[0]
-    owners = sorted(elements[1:])
+    owners = sorted(elements[1:], key=str.lower)
     return " ".join([path] + owners)
 
 

--- a/alphabetize_codeowners.py
+++ b/alphabetize_codeowners.py
@@ -8,12 +8,9 @@ lines
 
 import argparse
 import pathlib
-import re
 import sys
 
 __version__ = "0.0.1"
-
-WS_PAT = re.compile(r"\s+")
 
 
 def main() -> None:
@@ -68,7 +65,7 @@ def handle_file(fname: str, *, verbose: bool) -> int:
 def sort_line(line: str) -> str:
     # also normalizes whitespace
     dedented = line.lstrip()
-    elements = WS_PAT.split(dedented)
+    elements = dedented.split()
     path = elements[0]
     owners = sorted(elements[1:], key=str.lower)
     return " ".join([path] + owners)

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -3,3 +3,7 @@ from alphabetize_codeowners import sort_line
 
 def test_case_insensitivity():
     assert sort_line("path @B @a @c") == "path @a @B @c"
+
+
+def test_whitespace_normalization():
+    assert sort_line(" path  @a  @b  @c ") == "path @a @b @c"

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -1,0 +1,5 @@
+from alphabetize_codeowners import sort_line
+
+
+def test_case_insensitivity():
+    assert sort_line("path @B @a @c") == "path @a @B @c"


### PR DESCRIPTION
* Sort code owners alphabetically
* Fix whitespace normalization (`path__@a` did not normalize to `path_@a`)